### PR TITLE
add docs: create venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ python3 main.py
 ```sh
 git clone
 cd app
+python3 -m venv env
 source env/bin/activate
 pip3 install -r requirements.txt
 python3 main.py


### PR DESCRIPTION
Antes de activar el entorno virtual tenemos que crearlo. Se hizo el PR  para que en el README aparezca ese paso.